### PR TITLE
Better error handling

### DIFF
--- a/GhReleases.js
+++ b/GhReleases.js
@@ -125,9 +125,9 @@ var GhReleases = (function (_events$EventEmitter) {
         }
 
         var versionInZipUrl = matchReleaseUrl[1];
-        var currentVersion = semver.clean(tag);
-        if (versionInZipUrl !== currentVersion) {
-          throw new Error('The feedUrl does not link to latest tag (zipUrl=' + versionInZipUrl + '; currentVersion=' + currentVersion + ')');
+        var latestVersion = semver.clean(tag);
+        if (versionInZipUrl !== latestVersion) {
+          throw new Error('The feedUrl does not link to latest tag (zipUrl=' + versionInZipUrl + '; latestVersion=' + latestVersion + ')');
         }
 
         return feedUrl;

--- a/GhReleases.js
+++ b/GhReleases.js
@@ -107,7 +107,7 @@ var GhReleases = (function (_events$EventEmitter) {
       // Make sure feedUrl exists
       return got.get(feedUrl).then(function (res) {
         if (res.statusCode === 404) {
-          throw new Error('auto_updater.json does not exist or does not links to the latest GitHub release.');
+          throw new Error('auto_updater.json does not exist.');
         } else if (res.statusCode !== 200) {
           throw new Error('Unable to fetch auto_updater.json: ' + res.body);
         }

--- a/GhReleases.js
+++ b/GhReleases.js
@@ -121,7 +121,7 @@ var GhReleases = (function (_events$EventEmitter) {
 
         var matchReleaseUrl = zipUrl.match(REGEX_ZIP_URL);
         if (!matchReleaseUrl) {
-          throw new Error('The zipUrl (' + versionInZipUrl + ') is a invalid release URL');
+          throw new Error('The zipUrl (' + zipUrl + ') is a invalid release URL');
         }
 
         var versionInZipUrl = matchReleaseUrl[1];

--- a/GhReleases.js
+++ b/GhReleases.js
@@ -19,6 +19,7 @@ var events = require('events');
 
 var WIN32 = process.platform === 'win32';
 var DARWIN = process.platform === 'darwin';
+var REGEX_ZIP_URL = /\/v(\d+\.\d+\.\d+)\/.*\.zip/;
 
 var GhReleases = (function (_events$EventEmitter) {
   _inherits(GhReleases, _events$EventEmitter);
@@ -118,7 +119,12 @@ var GhReleases = (function (_events$EventEmitter) {
           throw new Error('Unable to parse the auto_updater.json: ' + err.message + ', body: ' + res.body);
         }
 
-        var versionInZipUrl = semver.clean(zipUrl.split('/').slice(-2, -1)[0]);
+        var matchReleaseUrl = zipUrl.match(REGEX_ZIP_URL);
+        if (!matchReleaseUrl) {
+          throw new Error('The zipUrl (' + versionInZipUrl + ') is a invalid release URL');
+        }
+
+        var versionInZipUrl = matchReleaseUrl[1];
         var currentVersion = semver.clean(tag);
         if (versionInZipUrl !== currentVersion) {
           throw new Error('The feedUrl does not link to latest tag (zipUrl=' + versionInZipUrl + '; currentVersion=' + currentVersion + ')');

--- a/src/GhReleases.js
+++ b/src/GhReleases.js
@@ -90,9 +90,9 @@ export default class GhReleases extends events.EventEmitter {
         }
 
         const versionInZipUrl = matchReleaseUrl[1]
-        const currentVersion = semver.clean(tag)
-        if (versionInZipUrl !== currentVersion) {
-          throw new Error('The feedUrl does not link to latest tag (zipUrl=' + versionInZipUrl + '; currentVersion=' + currentVersion + ')')
+        const latestVersion = semver.clean(tag)
+        if (versionInZipUrl !== latestVersion) {
+          throw new Error('The feedUrl does not link to latest tag (zipUrl=' + versionInZipUrl + '; latestVersion=' + latestVersion + ')')
         }
 
         return feedUrl

--- a/src/GhReleases.js
+++ b/src/GhReleases.js
@@ -86,7 +86,7 @@ export default class GhReleases extends events.EventEmitter {
 
         const matchReleaseUrl = zipUrl.match(REGEX_ZIP_URL)
         if (!matchReleaseUrl) {
-          throw new Error('The zipUrl (' + versionInZipUrl + ') is a invalid release URL')
+          throw new Error('The zipUrl (' + zipUrl + ') is a invalid release URL')
         }
 
         const versionInZipUrl = matchReleaseUrl[1]

--- a/src/GhReleases.js
+++ b/src/GhReleases.js
@@ -72,7 +72,7 @@ export default class GhReleases extends events.EventEmitter {
     return got.get(feedUrl)
       .then(res => {
         if (res.statusCode === 404) {
-          throw new Error('auto_updater.json does not exist or does not links to the latest GitHub release.')
+          throw new Error('auto_updater.json does not exist.')
         } else if (res.statusCode !== 200) {
           throw new Error('Unable to fetch auto_updater.json: ' + res.body)
         }

--- a/src/GhReleases.js
+++ b/src/GhReleases.js
@@ -77,7 +77,7 @@ export default class GhReleases extends events.EventEmitter {
           throw new Error('Unable to fetch auto_updater.json: ' + res.body)
         }
 
-        let zipUrl;
+        let zipUrl
         try {
           zipUrl = JSON.parse(res.body).url
         } catch (err) {
@@ -90,7 +90,7 @@ export default class GhReleases extends events.EventEmitter {
         }
 
         const versionInZipUrl = matchReleaseUrl[1]
-        const currentVersion = semver.clean(tag);
+        const currentVersion = semver.clean(tag)
         if (versionInZipUrl !== currentVersion) {
           throw new Error('The feedUrl does not link to latest tag (zipUrl=' + versionInZipUrl + '; currentVersion=' + currentVersion + ')')
         }

--- a/src/GhReleases.js
+++ b/src/GhReleases.js
@@ -5,6 +5,7 @@ const events = require('events')
 
 const WIN32 = (process.platform === 'win32')
 const DARWIN = (process.platform === 'darwin')
+const REGEX_ZIP_URL = /\/v(\d+\.\d+\.\d+)\/.*\.zip/
 
 export default class GhReleases extends events.EventEmitter {
 
@@ -83,7 +84,12 @@ export default class GhReleases extends events.EventEmitter {
           throw new Error('Unable to parse the auto_updater.json: ' + err.message + ', body: ' + res.body)
         }
 
-        const versionInZipUrl = semver.clean(zipUrl.split('/').slice(-2, -1)[0])
+        const matchReleaseUrl = zipUrl.match(REGEX_ZIP_URL)
+        if (!matchReleaseUrl) {
+          throw new Error('The zipUrl (' + versionInZipUrl + ') is a invalid release URL')
+        }
+
+        const versionInZipUrl = matchReleaseUrl[1]
         const currentVersion = semver.clean(tag);
         if (versionInZipUrl !== currentVersion) {
           throw new Error('The feedUrl does not link to latest tag (zipUrl=' + versionInZipUrl + '; currentVersion=' + currentVersion + ')')


### PR DESCRIPTION
The previous approach was too generic and was causing (at least for me)
some misunderstanding. Because even existing my “auto_updater.json” file
I was receiving that generic error message. And the real problem was
occurring while parsing the `res.body` because there was an extra comma
in my JSON file.
