### PR TITLE
Fix download URL for Windows

### DIFF
--- a/src/GhReleases.js
+++ b/src/GhReleases.js
@@ -60,7 +60,7 @@ export default class GhReleases extends events.EventEmitter {
     // If on Windows
     if (WIN32) {
       return new Promise((resolve, reject) => {
-        feedUrl = this.repoUrl + '/releases/download/' + tag
+        feedUrl = this.repoUrl + '/releases/tag/' + tag
         resolve(feedUrl)
       })
     }


### PR DESCRIPTION
The download URL used for Windows is incorrect. The module is currently using "https://github.com/user/repo/releases/download/3.0.0/" but it should be "https://github.com/user/repo/releases/tag/3.0.0/".