### PR TITLE
add autoUpdaterPath option

### DIFF
--- a/docs/2.x/api.md
+++ b/docs/2.x/api.md
@@ -39,6 +39,8 @@ updater.autoUpdater
 
 `currentVersion` - **Semver version** The current version of the running app.
 
+`autoUpdaterPath` - the path to the `auto_updater.json` file (default: root)
+
 ### Methods
 
 #### `.check([callback])`

--- a/src/GhReleases.js
+++ b/src/GhReleases.js
@@ -2,7 +2,7 @@ const semver = require('semver')
 const autoUpdater = require('electron').autoUpdater
 const got = require('got')
 const events = require('events')
-
+const path = require('path')
 const WIN32 = (process.platform === 'win32')
 const DARWIN = (process.platform === 'darwin')
 const REGEX_ZIP_URL = /\/(v)?(\d+\.\d+\.\d+)\/.*\.zip/
@@ -18,6 +18,7 @@ export default class GhReleases extends events.EventEmitter {
     self.repoUrl = 'https://github.com/' + gh.repo
     self.currentVersion = gh.currentVersion
     self.autoUpdater = autoUpdater
+    self.autoUpdaterPath = gh.autoUpdaterPath || ''
 
     self.autoUpdater.on('update-downloaded', (...args) => self.emit('update-downloaded', args))
   }
@@ -66,7 +67,15 @@ export default class GhReleases extends events.EventEmitter {
     }
 
     // On Mac we need to use the `auto_updater.json`
-    feedUrl = 'https://raw.githubusercontent.com/' + this.repo + '/master/auto_updater.json'
+    feedUrl = 'https://' +
+      path.join(
+        'raw.githubusercontent.com',
+        this.repo,
+        'master',
+        this.autoUpdaterPath,
+        'auto_updater.json'
+      )
+      console.log(feedUrl);
 
     // Make sure feedUrl exists
     return got.get(feedUrl)

--- a/test/test.js
+++ b/test/test.js
@@ -60,7 +60,7 @@ describe('GhReleases', function () {
   //   it('should make sure feed url exists', function (done) {
   //     updater._getFeedUrl('0.4.0')
   //       .then(function (feedUrl) {
-  //         assert.equal(feedUrl, 'https://raw.githubusercontent.com/jenslind/electron-gh-releases-test/master/darwin/auto_updater.json')
+  //         assert.equal(feedUrl, 'https://raw.githubusercontent.com/jenslind/electron-gh-releases-test/master/osx/auto_updater.json')
   //         done()
   //       }).catch(err => console.log(err))
   //   })

--- a/test/test.js
+++ b/test/test.js
@@ -6,9 +6,10 @@ describe('GhReleases', function () {
   this.timeout(7000)
 
   var updater = null
+  var options = {}
 
   before(function () {
-    var options = {
+    options = {
       repo: 'jenslind/electron-gh-releases-test',
       currentVersion: '1.0.0'
     }
@@ -49,4 +50,19 @@ describe('GhReleases', function () {
         })
     })
   })
+
+  // describe('_getFeedUrl() with an autoUpdaterPath', function () {
+  //   before(function() {
+  //     updater = new GhReleases(
+  //       Object.assign(options, { autoUpdaterPath: 'osx' })
+  //     )
+  //   })
+  //   it('should make sure feed url exists', function (done) {
+  //     updater._getFeedUrl('0.4.0')
+  //       .then(function (feedUrl) {
+  //         assert.equal(feedUrl, 'https://raw.githubusercontent.com/jenslind/electron-gh-releases-test/master/darwin/auto_updater.json')
+  //         done()
+  //       }).catch(err => console.log(err))
+  //   })
+  // })
 })


### PR DESCRIPTION
The project I'm working on has subdirectories for different OS so having the `auto_update.json` file always in the root breaks our conventions. Added an option `autoUpdaterPath` which lets users define where the json file is located in their repo.